### PR TITLE
Propagate error details from try! to fail! macro

### DIFF
--- a/examples/test.rs
+++ b/examples/test.rs
@@ -48,10 +48,7 @@ fn bar() -> EhResult<()> {
 }
 
 fn baz() -> EhResult<()> {
-    match bar() {
-        Err(err) => fail!(RecordNotFound, "could not find record", err),
-        Ok(x) => Ok(x),
-    }
+    Ok(try!(bar(), RecordNotFound, "could not find record"))
 }
 
 fn main() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -500,5 +500,10 @@ macro_rules! try {
     ($expr:expr) => (match $expr {
         Err(x) => fail!(x),
         Ok(x) => x,
-    })
+    });
+
+    ($expr:expr, $($err:expr),*) => (match $expr {
+        Err(x) => fail!($($err),*, x),
+        Ok(x) => x,
+    });
 }


### PR DESCRIPTION
Thought I'd give this a shot. Same thing that I suggested on discuss.

Makes it possible to specify error details with the `try!` macro as well.
